### PR TITLE
add a focused error message for bandnames with leading numbers

### DIFF
--- a/R/aoa.R
+++ b/R/aoa.R
@@ -147,7 +147,7 @@ aoa <- function(newdata,
   # handling of different raster formats
   as_stars <- FALSE
   as_terra <- FALSE
-  leading_digit <- all(grepl("[[:digit:]]",names(newdata)))
+  leading_digit <- any(grepl("^{1}[0-9]",n))
 
   if (inherits(newdata, "stars")) {
     if (!requireNamespace("stars", quietly = TRUE))

--- a/R/aoa.R
+++ b/R/aoa.R
@@ -147,7 +147,7 @@ aoa <- function(newdata,
   # handling of different raster formats
   as_stars <- FALSE
   as_terra <- FALSE
-  lead_digit <- all(grepl("[[:digit:]]",names(newdata)))
+  leading_digit <- all(grepl("[[:digit:]]",names(newdata)))
 
   if (inherits(newdata, "stars")) {
     if (!requireNamespace("stars", quietly = TRUE))

--- a/R/aoa.R
+++ b/R/aoa.R
@@ -147,6 +147,8 @@ aoa <- function(newdata,
   # handling of different raster formats
   as_stars <- FALSE
   as_terra <- FALSE
+  lead_digit <- all(grepl("[[:digit:]]",names(newdata)))
+
   if (inherits(newdata, "stars")) {
     if (!requireNamespace("stars", quietly = TRUE))
       stop("package stars required: install that first")
@@ -157,6 +159,7 @@ aoa <- function(newdata,
   if (inherits(newdata, "SpatRaster")) {
     if (!requireNamespace("terra", quietly = TRUE))
       stop("package terra required: install that first")
+
     newdata <- methods::as(newdata, "Raster")
     as_terra <- TRUE
   }
@@ -175,6 +178,8 @@ aoa <- function(newdata,
 
   # check if variables are in newdata
   if(any(trainDI$variables %in% names(newdata)==FALSE)){
+    if(leading_digit)
+      stop("names of newdata start with leading digits, automatically added 'X' results in mismatching names of train data in the model")
     stop("names of newdata don't match names of train data in the model")
   }
 

--- a/R/aoa.R
+++ b/R/aoa.R
@@ -178,7 +178,7 @@ aoa <- function(newdata,
 
   # check if variables are in newdata
   if(any(trainDI$variables %in% names(newdata)==FALSE)){
-    if(leading_digit)
+    if(!leading_digit)
       stop("names of newdata start with leading digits, automatically added 'X' results in mismatching names of train data in the model")
     stop("names of newdata don't match names of train data in the model")
   }


### PR DESCRIPTION
Since terra allows the layers in a stack to begin with a number, it will be automatically converted to an raster stack  via ` newdata <- methods::as(newdata, "Raster")
s`. Due to the raster conventions this is done by adding a leading _"X"_ to the layer name. Normally, however, model training and DI calculation have been carried out on the terra-stack without this leading _"X"_. 

The pull request checks whether the layer names have a leading number as name and points this out in the error message. 
Maybe this helps to avoid confusion about the message `"names of newdata don't match names of train data in the model"` which is thrown by default.
