### PR TITLE
W in geodist

### DIFF
--- a/R/geodist.R
+++ b/R/geodist.R
@@ -23,6 +23,7 @@
 #' @examples
 #' \dontrun{
 #' library(CAST)
+#' library(sf)
 #' library(terra)
 #' library(rnaturalearth)
 #' library(ggplot2)
@@ -175,6 +176,20 @@ geodist <- function(x,
   }
   class(dists) <- c("geodist", class(dists))
   attr(dists, "type") <- type
+
+  ##### Compute W if type=="geo" and test data and/or CV folds are provided
+  if(type == "geo"){
+    if(!is.null(testdata)){
+      W_test <- twosamples::wass_stat(dists[dists$what == "test-to-sample", "dist"],
+                                      dists[dists$what == "prediction-to-sample", "dist"])
+      attr(dists, "W_test") <- W_test
+    }
+    if(!is.null(cvfolds)){
+      W_CV <- twosamples::wass_stat(dists[dists$what == "CV-distances", "dist"],
+                                    dists[dists$what == "prediction-to-sample", "dist"])
+      attr(dists, "W_CV") <- W_CV
+    }
+  }
 
   return(dists)
 }

--- a/man/geodist.Rd
+++ b/man/geodist.Rd
@@ -54,6 +54,7 @@ See Meyer and Pebesma (2022) for an application of this plotting function
 \examples{
 \dontrun{
 library(CAST)
+library(sf)
 library(terra)
 library(rnaturalearth)
 library(ggplot2)


### PR DESCRIPTION
@HannaMeyer Added W statistic for test data and/or CV folds in `geodist` as attributes for `type="geo"`.

@JanLinnenbrink unfortunately we cannot use this implementation for the simulations since `geodist` doesn't accept `ppoints` and we need our W to be exactly comparable between CV methods. Will PR to `kNNDM_paper` ASAP.