### PR TITLE
imporves one of aoa's bottlenecks

### DIFF
--- a/R/aoa.R
+++ b/R/aoa.R
@@ -314,8 +314,7 @@ aoa <- function(newdata,
 
 
   # Distance Calculation ---------
-  okrows <- which(apply(newdata, 1, function(x)
-    all(!is.na(x))))
+  okrows <- which(rowSums(is.na(newdata)) == 0)
   newdataCC <- newdata[okrows, ,drop=F]
 
   if (method == "MD") {


### PR DESCRIPTION
This small code change makes aoa calculations about 3 times faster on a mid-size raster data (`size        : 696, 1212, 8  (nrow, ncol, nlyr)`)

```r
devtools::load_all()
library(sf)
library(terra)
library(caret)
library(viridis)

# prepare sample data:
data(cookfarm)
dat <- aggregate(cookfarm[,c("VW","Easting","Northing")],
   by=list(as.character(cookfarm$SOURCEID)),mean)
pts <- st_as_sf(dat,coords=c("Easting","Northing"),crs=26911)
pts$ID <- 1:nrow(pts)
set.seed(100)
pts <- pts[1:30,]
studyArea <- rast(system.file("extdata","predictors_2012-03-25.tif",package="CAST"))[[1:8]]
trainDat <- extract(studyArea,pts,na.rm=FALSE)
trainDat <- merge(trainDat,pts,by.x="ID",by.y="ID")

# train a model:
set.seed(100)
variables <- c("DEM","NDRE.Sd","TWI")
model <- train(trainDat[,which(names(trainDat)%in%variables)],
trainDat$VW, method="rf", importance=TRUE, tuneLength=1,
trControl=trainControl(method="cv",number=5,savePredictions=T))

# create larger data (for the benchmark)
studyArea_large = disagg(studyArea, 12)

bench::mark(aoa(studyArea_large, model),
            aoa2(studyArea_large, model),
          iterations = 5)
```

```
# A tibble: 2 × 13
  expression                        min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory                 time           gc              
  <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>                 <list>         <list>          
1 aoa(studyArea_large, model)     1.69s    1.84s     0.509     658MB     3.36     5    33      9.81s <aoa>  <Rprofmem [4,291 × 3]> <bench_tm [5]> <tibble [5 × 3]>
2 aoa2(studyArea_large, model) 348.76ms 482.14ms     1.56      643MB     4.68     5    15       3.2s <aoa>  <Rprofmem [3,751 × 3]> <bench_tm [5]> <tibble [5 × 3]>
```